### PR TITLE
fix EventIndex() overflow by using int64_t

### DIFF
--- a/apps/runs-test/ks/red_black/hval.h
+++ b/apps/runs-test/ks/red_black/hval.h
@@ -4,6 +4,7 @@
 union hval_un
 {
 	int i;
+	int64_t i64;
 	double d;
 	void *v;
 	char *s;

--- a/apps/runs-test/ks/red_black/hval_2.h
+++ b/apps/runs-test/ks/red_black/hval_2.h
@@ -4,6 +4,7 @@
 union hval_un
 {
 	int i;
+	int64_t i64;
 	double d;
 	void *v;
 	char *s;

--- a/apps/runs-test/ks/red_black/red_black_2.c
+++ b/apps/runs-test/ks/red_black/red_black_2.c
@@ -12,6 +12,7 @@
 int CompareKeyType(KEY_t op1, KEY_t op2)
 {
 	int i1, i2;
+	int64_t i64_1, i64_2;
 	double d1, d2;
 	char *s1, *s2;
 	/*
@@ -19,63 +20,87 @@ int CompareKeyType(KEY_t op1, KEY_t op2)
 	 * return > 0 => op1 > op2
          * return == 0 => op1 == op2
          */
-	switch(op1.type)
+	switch (op1.type)
 	{
-		case K_INT:
-			i1 = op1.key.i;
-			i2 = op2.key.i;
-			if(i1 < i2) {
-				return(-1);
-			} else if (i1 > i2) {
-				return (1);
-			} else return(0);
-			break;
-		case K_DOUBLE:
-			d1 = op1.key.d;
-			d2 = op2.key.d;
-			if(d1 < d2) {
-				return(-1);
-			} else if (d1 > d2) {
-				return (1);
-			} else return(0);
-			break;
-		case K_STRING:
-			/*
+	case K_INT:
+		i1 = op1.key.i;
+		i2 = op2.key.i;
+		if (i1 < i2)
+		{
+			return (-1);
+		}
+		else if (i1 > i2)
+		{
+			return (1);
+		}
+		else
+			return (0);
+		break;
+	case K_INT64:
+		i64_1 = op1.key.i64;
+		i64_2 = op2.key.i64;
+		if (i64_1 < i64_2)
+		{
+			return (-1);
+		}
+		else if (i64_1 > i64_2)
+		{
+			return (1);
+		}
+		else
+			return (0);
+		break;
+	case K_DOUBLE:
+		d1 = op1.key.d;
+		d2 = op2.key.d;
+		if (d1 < d2)
+		{
+			return (-1);
+		}
+		else if (d1 > d2)
+		{
+			return (1);
+		}
+		else
+			return (0);
+		break;
+	case K_STRING:
+		/*
 		 	 * need to do it this way in case the strings
 			 * are the same since strcmp doesn't handle overlap
 			 * if they overlap but are not the same the
 			 * results will depend on strcmp
 			 */
-			s1 = op1.key.s;
-			s2 = op2.key.s;
-			if(s1 == s2) {
-				return(0);
-			}
-			return(strcmp(s1,s2));
-			break;
-		default:
-			fprintf(stderr,
-			  "CompareKeyType: bad type %d\n",op1.type);
-			fflush(stderr);
-			exit(1);
+		s1 = op1.key.s;
+		s2 = op2.key.s;
+		if (s1 == s2)
+		{
+			return (0);
+		}
+		return (strcmp(s1, s2));
+		break;
+	default:
+		fprintf(stderr,
+				"CompareKeyType: bad type %d\n", op1.type);
+		fflush(stderr);
+		exit(1);
 	}
 
-	return(0);
+	return (0);
 }
-			
 
 RB *RBInit()
 {
 	RB *node;
 
 	node = (RB *)malloc(sizeof(RB));
-	if(node == NULL)
+	if (node == NULL)
 	{
-		return(NULL);
+		return (NULL);
 	}
-	memset(node,0,sizeof(RB));
+	memset(node, 0, sizeof(RB));
 
-	return(node);
+	return (node);
 }
 
 void RBFree(RB *node)
@@ -89,51 +114,51 @@ RB *RBTreeInit(unsigned char type)
 	RB *node;
 
 	node = RBInit();
-	node->color = RB_GREEN;		/* need this if the root rotates */
+	node->color = RB_GREEN; /* need this if the root rotates */
 	node->key.type = type;
 
-	return(node);
+	return (node);
 }
 
 RB *RBGrandP(RB *node)
 {
-	if((node == NULL) || (node->parent == NULL) ||
+	if ((node == NULL) || (node->parent == NULL) ||
 		(node->parent->parent == NULL) ||
-                (node->parent->parent->color == RB_GREEN))
+		(node->parent->parent->color == RB_GREEN))
 	{
-		return(NULL);
+		return (NULL);
 	}
-	
-	return(node->parent->parent);
+
+	return (node->parent->parent);
 }
 
 RB *RBUncle(RB *node)
 {
 	RB *gp;
 
-	if(node == NULL)
+	if (node == NULL)
 	{
-		return(NULL);
+		return (NULL);
 	}
 
-	if(node->parent == NULL)
+	if (node->parent == NULL)
 	{
-		return(NULL);
+		return (NULL);
 	}
 
 	gp = RBGrandP(node);
-	if(gp == NULL)
+	if (gp == NULL)
 	{
-		return(NULL);
+		return (NULL);
 	}
 
-	if(node->parent == gp->left)
+	if (node->parent == gp->left)
 	{
-		return(gp->right);
+		return (gp->right);
 	}
 	else
 	{
-		return(gp->left);
+		return (gp->left);
 	}
 }
 
@@ -142,13 +167,13 @@ RB *RBInitTree()
 	RB *tree;
 
 	tree = RBInit();
-	if(tree == NULL)
+	if (tree == NULL)
 	{
-		return(NULL);
+		return (NULL);
 	}
-	tree->color = RB_GREEN;		/* uninitialized */
+	tree->color = RB_GREEN; /* uninitialized */
 
-	return(tree);
+	return (tree);
 }
 
 RB *RBAddTree(RB *parent, KEY_t key, Hval value, RB *top)
@@ -158,17 +183,17 @@ RB *RBAddTree(RB *parent, KEY_t key, Hval value, RB *top)
 	/*
 	 * if this is the very root, use the left child
 	 */
-	if(parent->color == RB_GREEN)
+	if (parent->color == RB_GREEN)
 	{
 		/*
 		 * if there isn't a node at the top, make one
 		 */
-		if(parent->left == NULL)
+		if (parent->left == NULL)
 		{
 			node = RBInit();
-			if(node == NULL)
+			if (node == NULL)
 			{
-				return(NULL);
+				return (NULL);
 			}
 			node->key = key;
 			node->value = value;
@@ -180,21 +205,21 @@ RB *RBAddTree(RB *parent, KEY_t key, Hval value, RB *top)
 			 */
 			parent->prev = node;
 			parent->next = node;
-			return(node);
+			return (node);
 		}
-		else	/* start down the garden path */
+		else /* start down the garden path */
 		{
-			return(RBAddTree(parent->left,key,value,top));
+			return (RBAddTree(parent->left, key, value, top));
 		}
 	}
-	else if(CompareKeyType(key,parent->key) < 0)
+	else if (CompareKeyType(key, parent->key) < 0)
 	{
-		if(parent->left == NULL)
+		if (parent->left == NULL)
 		{
 			node = RBInit();
-			if(node == NULL)
+			if (node == NULL)
 			{
-				return(NULL);
+				return (NULL);
 			}
 			node->value = value;
 			node->key = key;
@@ -204,7 +229,7 @@ RB *RBAddTree(RB *parent, KEY_t key, Hval value, RB *top)
 			/*
 			 * insert in linked list
 			 */
-			if(parent->prev)
+			if (parent->prev)
 			{
 				parent->prev->next = node;
 			}
@@ -216,23 +241,23 @@ RB *RBAddTree(RB *parent, KEY_t key, Hval value, RB *top)
 			/*
 			 * new head of the list?
 			 */
-			if(top->prev == parent)
+			if (top->prev == parent)
 			{
 				top->prev = node;
 			}
-			return(node);
+			return (node);
 		}
 		else
 		{
-			return(RBAddTree(parent->left,key,value,top));
+			return (RBAddTree(parent->left, key, value, top));
 		}
 	}
-	else if(parent->right == NULL)
+	else if (parent->right == NULL)
 	{
 		node = RBInit();
-		if(node == NULL)
+		if (node == NULL)
 		{
-			return(NULL);
+			return (NULL);
 		}
 		node->value = value;
 		node->key = key;
@@ -242,7 +267,7 @@ RB *RBAddTree(RB *parent, KEY_t key, Hval value, RB *top)
 		/*
 		 * insert in linked list
 		 */
-		if(parent->next != NULL)
+		if (parent->next != NULL)
 		{
 			parent->next->prev = node;
 		}
@@ -251,15 +276,15 @@ RB *RBAddTree(RB *parent, KEY_t key, Hval value, RB *top)
 		node->prev = parent;
 		parent->next = node;
 
-		if(top->next == parent)
+		if (top->next == parent)
 		{
 			top->next = node;
 		}
-		return(node);
+		return (node);
 	}
 	else
 	{
-		return(RBAddTree(parent->right,key,value,top));
+		return (RBAddTree(parent->right, key, value, top));
 	}
 }
 
@@ -273,7 +298,7 @@ void RBRotateLeft(RB *root)
 	RB *new_root_left = new_root->left;
 	RB *new_root_right = new_root->right;
 
-	if((root_parent != NULL) && (root_parent->color == RB_GREEN))
+	if ((root_parent != NULL) && (root_parent->color == RB_GREEN))
 	{
 		top = root_parent;
 		root_parent = NULL;
@@ -284,16 +309,16 @@ void RBRotateLeft(RB *root)
 	}
 
 	root->right = new_root_left;
-	if(new_root_left)
+	if (new_root_left)
 	{
 		new_root_left->parent = root;
 	}
 	new_root->left = root;
 	root->parent = new_root;
 
-	if(root_parent != NULL)
+	if (root_parent != NULL)
 	{
-		if(root_parent->left == root)
+		if (root_parent->left == root)
 		{
 			root_parent->left = new_root;
 		}
@@ -307,15 +332,13 @@ void RBRotateLeft(RB *root)
 	/*
 	 * reset if the top of the tree rotates
 	 */
-	if(top != NULL)
+	if (top != NULL)
 	{
 		top->left = new_root;
 		new_root->parent = top;
 	}
 
-
 	return;
-
 }
 
 void RBRotateRight(RB *root)
@@ -328,7 +351,7 @@ void RBRotateRight(RB *root)
 	RB *new_root_left = new_root->left;
 	RB *new_root_right = new_root->right;
 
-	if((root_parent != NULL) && (root_parent->color == RB_GREEN))
+	if ((root_parent != NULL) && (root_parent->color == RB_GREEN))
 	{
 		top = root_parent;
 		root_parent = NULL;
@@ -339,16 +362,16 @@ void RBRotateRight(RB *root)
 	}
 
 	root->left = new_root_right;
-	if(new_root_right)
+	if (new_root_right)
 	{
 		new_root_right->parent = root;
 	}
 	new_root->right = root;
 	root->parent = new_root;
 
-	if(root_parent != NULL)
+	if (root_parent != NULL)
 	{
-		if(root_parent->left == root)
+		if (root_parent->left == root)
 		{
 			root_parent->left = new_root;
 		}
@@ -359,14 +382,13 @@ void RBRotateRight(RB *root)
 	}
 	new_root->parent = root_parent;
 
-	if(top != NULL)
+	if (top != NULL)
 	{
 		top->left = new_root;
 		new_root->parent = top;
 	}
 
 	return;
-
 }
 
 void RBInsert5(RB *node)
@@ -375,19 +397,19 @@ void RBInsert5(RB *node)
 
 	gp = RBGrandP(node);
 
-	if(node->parent->color != RB_GREEN)
+	if (node->parent->color != RB_GREEN)
 	{
 		node->parent->color = RB_BLACK;
 	}
 
-	if(gp && (node == node->parent->left) && (node->parent == gp->left))
+	if (gp && (node == node->parent->left) && (node->parent == gp->left))
 	{
 		gp->color = RB_RED;
 		RBRotateRight(gp);
 		return;
 	}
 
-	if(gp && (node == node->parent->right) && (node->parent == gp->right))
+	if (gp && (node == node->parent->right) && (node->parent == gp->right))
 	{
 		gp->color = RB_RED;
 		RBRotateLeft(gp);
@@ -403,8 +425,7 @@ void RBInsert4(RB *node)
 	RB *new_node;
 	int is_top;
 
-
-	if(node->parent->color == RB_GREEN)
+	if (node->parent->color == RB_GREEN)
 	{
 		is_top = 1;
 	}
@@ -414,36 +435,36 @@ void RBInsert4(RB *node)
 	}
 
 	gp = RBGrandP(node);
-	if(!is_top && (node == node->parent->right) && 
-				(node->parent == gp->left))
+	if (!is_top && (node == node->parent->right) &&
+		(node->parent == gp->left))
 	{
 		RBRotateLeft(node->parent);
 		new_node = node->left;
 	}
-	else if(!is_top && (node == node->parent->left) && 
-					(node->parent == gp->right))
+	else if (!is_top && (node == node->parent->left) &&
+			 (node->parent == gp->right))
 	{
 		RBRotateRight(node->parent);
 		new_node = node->right;
 	}
 	else
 	{
-		new_node = node;	/* skip to step 5 with "node" */
+		new_node = node; /* skip to step 5 with "node" */
 	}
 	RBInsert5(new_node);
 
 	return;
 }
 
-void RBInsert1(RB *node);	/* forward def */
-	
+void RBInsert1(RB *node); /* forward def */
+
 void RBInsert3(RB *node)
 {
 	RB *uncle;
 	RB *gp;
 
 	uncle = RBUncle(node);
-	if((uncle != NULL) && (uncle->color == RB_RED))
+	if ((uncle != NULL) && (uncle->color == RB_RED))
 	{
 		node->parent->color = RB_BLACK;
 		uncle->color = RB_BLACK;
@@ -457,11 +478,10 @@ void RBInsert3(RB *node)
 
 	return;
 }
-		
 
 void RBInsert2(RB *node)
 {
-	if(node->parent->color == RB_BLACK)
+	if (node->parent->color == RB_BLACK)
 	{
 		return;
 	}
@@ -469,13 +489,11 @@ void RBInsert2(RB *node)
 	RBInsert3(node);
 
 	return;
-
 }
-	
 
 void RBInsert1(RB *node)
 {
-	if(node->parent->color == RB_GREEN)
+	if (node->parent->color == RB_GREEN)
 	{
 		node->color = RB_BLACK;
 		return;
@@ -490,10 +508,10 @@ void RBInsert(RB *tree, KEY_t key, Hval value)
 {
 	RB *node;
 
-	node = RBAddTree(tree,key,value,tree);
-	if(node == NULL)
+	node = RBAddTree(tree, key, value, tree);
+	if (node == NULL)
 	{
-		fprintf(stderr,"RBInsert failed\n");
+		fprintf(stderr, "RBInsert failed\n");
 		fflush(stderr);
 		exit(1);
 	}
@@ -507,55 +525,53 @@ void RBInsert(RB *tree, KEY_t key, Hval value)
 
 RB *RBFindNode(RB *node, KEY_t key)
 {
-	if(node == NULL)
+	if (node == NULL)
 	{
-		return(NULL);
+		return (NULL);
 	}
-	if(CompareKeyType(node->key,key) == 0)
+	if (CompareKeyType(node->key, key) == 0)
 	{
-		return(node);
+		return (node);
 	}
 
-	if(CompareKeyType(key,node->key) < 0)
+	if (CompareKeyType(key, node->key) < 0)
 	{
-		return(RBFindNode(node->left,key));
+		return (RBFindNode(node->left, key));
 	}
 	else
 	{
-		return(RBFindNode(node->right,key));
+		return (RBFindNode(node->right, key));
 	}
 }
-		
 
 RB *RBFind(RB *tree, KEY_t key)
 {
 	RB *node;
 
-	if(tree->left == NULL)
+	if (tree->left == NULL)
 	{
-		return(NULL);
+		return (NULL);
 	}
 
-	node = RBFindNode(tree->left,key);
+	node = RBFindNode(tree->left, key);
 
-	return(node);
+	return (node);
 }
-
 
 RB *RBSibling(RB *node)
 {
-	if(node->parent->color == RB_GREEN)
+	if (node->parent->color == RB_GREEN)
 	{
-		return(NULL);
+		return (NULL);
 	}
 
-	if(node == node->parent->left)
+	if (node == node->parent->left)
 	{
-		return(node->parent->right);
+		return (node->parent->right);
 	}
 	else
 	{
-		return(node->parent->left);
+		return (node->parent->left);
 	}
 }
 
@@ -568,9 +584,9 @@ void RBDelete6(RB *node)
 	sib = RBSibling(node);
 	sib->color = node->parent->color;
 	node->parent->color = RB_BLACK;
-	if(node == node->parent->left)
+	if (node == node->parent->left)
 	{
-		if(sib->right)
+		if (sib->right)
 		{
 			sib->right->color = RB_BLACK;
 		}
@@ -578,7 +594,7 @@ void RBDelete6(RB *node)
 	}
 	else
 	{
-		if(sib->left)
+		if (sib->left)
 		{
 			sib->left->color = RB_BLACK;
 		}
@@ -588,32 +604,31 @@ void RBDelete6(RB *node)
 	return;
 }
 
-
 void RBDelete5(RB *node)
 {
 	RB *sib;
 
 	sib = RBSibling(node);
 
-	if(sib->color == RB_BLACK)
+	if (sib->color == RB_BLACK)
 	{
-		if((node == node->parent->left) && 
-		   (!sib->right || (sib->right->color == RB_BLACK)) &&
-		   (sib->left && (sib->left->color == RB_RED)))
+		if ((node == node->parent->left) &&
+			(!sib->right || (sib->right->color == RB_BLACK)) &&
+			(sib->left && (sib->left->color == RB_RED)))
 		{
 			sib->color = RB_RED;
-			if(sib->left)
+			if (sib->left)
 			{
 				sib->left->color = RB_BLACK;
 			}
 			RBRotateRight(sib);
 		}
-		else if((node == node->parent->right) &&
-		(!sib->left || (sib->left->color == RB_BLACK)) &&
-		(sib->right && (sib->right->color == RB_RED)))
+		else if ((node == node->parent->right) &&
+				 (!sib->left || (sib->left->color == RB_BLACK)) &&
+				 (sib->right && (sib->right->color == RB_RED)))
 		{
 			sib->color = RB_RED;
-			if(sib->right)
+			if (sib->right)
 			{
 				sib->right->color = RB_BLACK;
 			}
@@ -623,17 +638,17 @@ void RBDelete5(RB *node)
 	RBDelete6(node);
 	return;
 }
-	
+
 void RBDelete4(RB *node)
 {
 	RB *sib;
 
 	sib = RBSibling(node);
 
-	if((node->parent->color == RB_RED) &&
-	   (sib->color == RB_BLACK) &&
-	   (!sib->left || (sib->left->color == RB_BLACK)) &&
-	   (!sib->right || (sib->right->color == RB_BLACK)))
+	if ((node->parent->color == RB_RED) &&
+		(sib->color == RB_BLACK) &&
+		(!sib->left || (sib->left->color == RB_BLACK)) &&
+		(!sib->right || (sib->right->color == RB_BLACK)))
 	{
 		sib->color = RB_RED;
 		node->parent->color = RB_BLACK;
@@ -650,10 +665,10 @@ void RBDelete3(RB *node)
 	RB *sib;
 
 	sib = RBSibling(node);
-	if((node->parent->color == RB_BLACK) &&
-	   (sib->color == RB_BLACK) &&
-	   (!sib->left || (sib->left->color == RB_BLACK)) &&
-	   (!sib->right || (sib->right->color == RB_BLACK)))
+	if ((node->parent->color == RB_BLACK) &&
+		(sib->color == RB_BLACK) &&
+		(!sib->left || (sib->left->color == RB_BLACK)) &&
+		(!sib->right || (sib->right->color == RB_BLACK)))
 	{
 		sib->color = RB_RED;
 		RBDelete1(node->parent);
@@ -664,18 +679,17 @@ void RBDelete3(RB *node)
 	}
 	return;
 }
-	
 
 void RBDelete2(RB *node)
 {
 	RB *sib;
 
 	sib = RBSibling(node);
-	if(sib->color == RB_RED)
+	if (sib->color == RB_RED)
 	{
 		node->parent->color = RB_RED;
 		sib->color = RB_BLACK;
-		if(node == node->parent->left)
+		if (node == node->parent->left)
 		{
 			RBRotateLeft(node->parent);
 		}
@@ -687,11 +701,10 @@ void RBDelete2(RB *node)
 	RBDelete3(node);
 	return;
 }
-	
 
 void RBDelete1(RB *node)
 {
-	if(node->parent->color != RB_GREEN)
+	if (node->parent->color != RB_GREEN)
 	{
 		RBDelete2(node);
 	}
@@ -706,7 +719,7 @@ void RBDeleteOneChild(RB *node)
 	 */
 	RB *child;
 
-	if(node->left)
+	if (node->left)
 	{
 		child = node->left;
 	}
@@ -715,7 +728,7 @@ void RBDeleteOneChild(RB *node)
 		child = node->right;
 	}
 
-	if(child == NULL)
+	if (child == NULL)
 	{
 		/*
 		 * child == NULL means child is black
@@ -723,11 +736,11 @@ void RBDeleteOneChild(RB *node)
 		 * parent black needs help, but parent red is
 		 * just a delete
 		 */
-		if(node->color == RB_BLACK)
+		if (node->color == RB_BLACK)
 		{
 			RBDelete1(node);
 		}
-		if(node == node->parent->left)
+		if (node == node->parent->left)
 		{
 			node->parent->left = NULL;
 		}
@@ -735,11 +748,11 @@ void RBDeleteOneChild(RB *node)
 		{
 			node->parent->right = NULL;
 		}
-		if(node->next)
+		if (node->next)
 		{
 			node->next->prev = node->prev;
 		}
-		if(node->prev)
+		if (node->prev)
 		{
 			node->prev->next = node->next;
 		}
@@ -751,9 +764,8 @@ void RBDeleteOneChild(RB *node)
 	 * splice out the node for the child
 	 */
 
-
 	child->parent = node->parent;
-	if(node->parent->left == node)
+	if (node->parent->left == node)
 	{
 		node->parent->left = child;
 	}
@@ -762,30 +774,30 @@ void RBDeleteOneChild(RB *node)
 		node->parent->right = child;
 	}
 
-	if(node->next && (node->next != child))
+	if (node->next && (node->next != child))
 	{
 		node->next->prev = child;
 	}
-	if(node->next != child)
+	if (node->next != child)
 	{
 		child->next = node->next;
 	}
-	if(node->prev && (node->prev != child))
+	if (node->prev && (node->prev != child))
 	{
 		node->prev->next = child;
 	}
-	if(node->prev != child)
+	if (node->prev != child)
 	{
 		child->prev = node->prev;
 	}
 
-	if(node->parent->color == RB_GREEN)
+	if (node->parent->color == RB_GREEN)
 	{
-		if(node->parent->next == node)
+		if (node->parent->next == node)
 		{
 			node->parent->next = child;
 		}
-		if(node->parent->prev == node)
+		if (node->parent->prev == node)
 		{
 			node->parent->prev = child;
 		}
@@ -796,9 +808,9 @@ void RBDeleteOneChild(RB *node)
 	 * child substituted in
 	 */
 
-	if(node->color == RB_BLACK)
+	if (node->color == RB_BLACK)
 	{
-		if(child->color == RB_RED)
+		if (child->color == RB_RED)
 		{
 			child->color = RB_BLACK;
 		}
@@ -817,14 +829,14 @@ RB *RBSwapMaxLeft(RB *node)
 	KEY_t tempk;
 	Hval tempv;
 
-	if(node->left == NULL)
+	if (node->left == NULL)
 	{
-		return(NULL);
+		return (NULL);
 	}
 
 	curr = node->left;
 
-	while(curr->right != NULL)
+	while (curr->right != NULL)
 	{
 		curr = curr->right;
 	}
@@ -837,25 +849,24 @@ RB *RBSwapMaxLeft(RB *node)
 	curr->value = node->value;
 	node->value = tempv;
 
-	return(curr);
+	return (curr);
 }
-	
 
 void RBDeleteNode(RB *tree, RB *node)
 {
 	RB *target;
 
-	if(node->left && node->right)
+	if (node->left && node->right)
 	{
 		target = RBSwapMaxLeft(node);
 		/*
 		 * may need to swap the head and tail
 		 */
-		if(tree->prev == target)
+		if (tree->prev == target)
 		{
 			tree->prev = node;
 		}
-		if(tree->next == target)
+		if (tree->next == target)
 		{
 			tree->next = node;
 		}
@@ -868,20 +879,19 @@ void RBDeleteNode(RB *tree, RB *node)
 	RBDeleteOneChild(target);
 
 	return;
-
 }
 
 void RBDelete(RB *tree, RB *node)
 {
-	if(tree->prev && (tree->prev == node))
+	if (tree->prev && (tree->prev == node))
 	{
 		tree->prev = node->next;
 	}
-	if(tree->next && (tree->next == node))
+	if (tree->next && (tree->next == node))
 	{
 		tree->next = node->prev;
 	}
-	RBDeleteNode(tree,node);
+	RBDeleteNode(tree, node);
 
 	return;
 }
@@ -892,16 +902,16 @@ void RBDeleteTree(RB *tree)
 	RB *next;
 
 	node = tree->prev;
-	if(node != NULL)
+	if (node != NULL)
 	{
 		next = node->next;
 	}
 
-	while(node)
+	while (node)
 	{
 		RBFree(node);
 		node = next;
-		if(node == NULL)
+		if (node == NULL)
 		{
 			break;
 		}
@@ -918,17 +928,17 @@ RB *RBInitD()
 {
 	RB *rb = RBTreeInit(K_DOUBLE);
 
-	return(rb);
+	return (rb);
 }
 
 void RBDestroyD(RB *rb)
 {
-	return(RBDeleteTree(rb));
+	return (RBDeleteTree(rb));
 }
 
 void RBDeleteD(RB *rb, RB *node)
 {
-	return(RBDelete(rb,node));
+	return (RBDelete(rb, node));
 }
 
 RB *RBFindD(RB *rb, double dkey)
@@ -937,7 +947,7 @@ RB *RBFindD(RB *rb, double dkey)
 
 	key.type = K_DOUBLE;
 	key.key.d = dkey;
-	return(RBFind(rb,key));
+	return (RBFind(rb, key));
 }
 
 void RBInsertD(RB *rb, double dkey, Hval value)
@@ -946,23 +956,23 @@ void RBInsertD(RB *rb, double dkey, Hval value)
 
 	key.type = K_DOUBLE;
 	key.key.d = dkey;
-	return(RBInsert(rb,key,value));
+	return (RBInsert(rb, key, value));
 }
 
 RB *RBInitI()
 {
 	RB *rb = RBTreeInit(K_INT);
-	return(rb);
+	return (rb);
 }
 
 void RBDestroyI(RB *rb)
 {
-	return(RBDeleteTree(rb));
+	return (RBDeleteTree(rb));
 }
 
 void RBDeleteI(RB *rb, RB *node)
 {
-	return(RBDelete(rb,node));
+	return (RBDelete(rb, node));
 }
 
 RB *RBFindI(RB *rb, int ikey)
@@ -971,7 +981,7 @@ RB *RBFindI(RB *rb, int ikey)
 
 	key.type = K_INT;
 	key.key.i = ikey;
-	return(RBFind(rb,key));
+	return (RBFind(rb, key));
 }
 
 void RBInsertI(RB *rb, int ikey, Hval value)
@@ -980,23 +990,57 @@ void RBInsertI(RB *rb, int ikey, Hval value)
 
 	key.type = K_INT;
 	key.key.i = ikey;
-	return(RBInsert(rb,key,value));
+	return (RBInsert(rb, key, value));
+}
+
+RB *RBInitI64()
+{
+	RB *rb = RBTreeInit(K_INT64);
+	return (rb);
+}
+
+void RBDestroyI64(RB *rb)
+{
+	return (RBDeleteTree(rb));
+}
+
+void RBDeleteI64(RB *rb, RB *node)
+{
+	return (RBDelete(rb, node));
+}
+
+RB *RBFindI64(RB *rb, int64_t ikey)
+{
+	KEY_t key;
+
+	key.type = K_INT64;
+	key.key.i64 = ikey;
+	return (RBFind(rb, key));
+}
+
+void RBInsertI64(RB *rb, int64_t ikey, Hval value)
+{
+	KEY_t key;
+
+	key.type = K_INT64;
+	key.key.i64 = ikey;
+	return (RBInsert(rb, key, value));
 }
 
 RB *RBInitS()
 {
 	RB *rb = RBTreeInit(K_STRING);
-	return(rb);
+	return (rb);
 }
 
 void RBDestroyS(RB *rb)
 {
-	return(RBDeleteTree(rb));
+	return (RBDeleteTree(rb));
 }
 
 void RBDeleteS(RB *rb, RB *node)
 {
-	return(RBDelete(rb,node));
+	return (RBDelete(rb, node));
 }
 
 RB *RBFindS(RB *rb, char *skey)
@@ -1005,7 +1049,7 @@ RB *RBFindS(RB *rb, char *skey)
 
 	key.type = K_STRING;
 	key.key.s = skey;
-	return(RBFind(rb,key));
+	return (RBFind(rb, key));
 }
 
 void RBInsertS(RB *rb, char *skey, Hval value)
@@ -1014,7 +1058,7 @@ void RBInsertS(RB *rb, char *skey, Hval value)
 
 	key.type = K_STRING;
 	key.key.s = skey;
-	return(RBInsert(rb,key,value));
+	return (RBInsert(rb, key, value));
 }
 
 #ifdef DEBUG_RB
@@ -1024,22 +1068,22 @@ int RBTestGP(RB *node)
 	RB *parent = node->parent;
 	RB *gp = RBGrandP(node);
 
-	if(gp == NULL)
+	if (gp == NULL)
 	{
-		return(1);
+		return (1);
 	}
 
-	if(parent == gp->left)
+	if (parent == gp->left)
 	{
-		return(1);
+		return (1);
 	}
 
-	if(parent == gp->right)
+	if (parent == gp->right)
 	{
-		return(1);
+		return (1);
 	}
 
-	return(0);
+	return (0);
 }
 
 int RBTestGPs(RB *tree)
@@ -1049,30 +1093,29 @@ int RBTestGPs(RB *tree)
 
 	top = tree->left;
 
-	if(top->left)
+	if (top->left)
 	{
 		status = RBTestGP(top->left);
-		if(status == 0)
+		if (status == 0)
 		{
-			return(0);
+			return (0);
 		}
 	}
-	if(top->right)
+	if (top->right)
 	{
 		status = RBTestGP(top->right);
-		if(status == 0)
+		if (status == 0)
 		{
-			return(0);
+			return (0);
 		}
 	}
 
-	return(1);
+	return (1);
 }
-
 
 void RBTestChildColor(RB *tree, int *both_black)
 {
-	if(tree == NULL)
+	if (tree == NULL)
 	{
 		return;
 	}
@@ -1083,19 +1126,19 @@ void RBTestChildColor(RB *tree, int *both_black)
 	 *
 	 * null child is black
 	 */
-	if(tree->color == RB_RED)
+	if (tree->color == RB_RED)
 	{
-		if(tree->left)
+		if (tree->left)
 		{
-			if(tree->left->color != RB_BLACK)
+			if (tree->left->color != RB_BLACK)
 			{
 				*both_black = 0;
 				return;
 			}
 		}
-		if(tree->right)
+		if (tree->right)
 		{
-			if(tree->right->color != RB_BLACK)
+			if (tree->right->color != RB_BLACK)
 			{
 				*both_black = 0;
 				return;
@@ -1104,20 +1147,19 @@ void RBTestChildColor(RB *tree, int *both_black)
 	}
 	else
 	{
-		RBTestChildColor(tree->left,both_black);
-		if(*both_black == 0)
+		RBTestChildColor(tree->left, both_black);
+		if (*both_black == 0)
 		{
 			return;
 		}
-		RBTestChildColor(tree->right,both_black);
-		if(*both_black == 0)
+		RBTestChildColor(tree->right, both_black);
+		if (*both_black == 0)
 		{
 			return;
 		}
 	}
 
 	return;
-
 }
 
 int RBTestPaths(RB *tree, int *black_count, int *status)
@@ -1131,9 +1173,9 @@ int RBTestPaths(RB *tree, int *black_count, int *status)
 	int left_black;
 	int right_black;
 
-	if(tree->left == NULL)
+	if (tree->left == NULL)
 	{
-		if(tree->color == RB_BLACK)
+		if (tree->color == RB_BLACK)
 		{
 			left_black = 2;
 		}
@@ -1144,20 +1186,20 @@ int RBTestPaths(RB *tree, int *black_count, int *status)
 	}
 	else
 	{
-		RBTestPaths(tree->left,&left_black,status);
-		if(*status == 0)
+		RBTestPaths(tree->left, &left_black, status);
+		if (*status == 0)
 		{
 			return;
 		}
-		if(tree->color == RB_BLACK)
+		if (tree->color == RB_BLACK)
 		{
 			left_black++;
 		}
 	}
 
-	if(tree->right == NULL)
+	if (tree->right == NULL)
 	{
-		if(tree->color == RB_BLACK)
+		if (tree->color == RB_BLACK)
 		{
 			right_black = 2;
 		}
@@ -1168,29 +1210,27 @@ int RBTestPaths(RB *tree, int *black_count, int *status)
 	}
 	else
 	{
-		RBTestPaths(tree->right,&right_black,status);
-		if(*status == 0)
+		RBTestPaths(tree->right, &right_black, status);
+		if (*status == 0)
 		{
 			return;
 		}
-		if(tree->color == RB_BLACK)
+		if (tree->color == RB_BLACK)
 		{
 			right_black++;
 		}
 	}
 
-	if(left_black != right_black)
+	if (left_black != right_black)
 	{
 		*status = 0;
 	}
 	else
 	{
-		*black_count = left_black;	/* they are the same */
+		*black_count = left_black; /* they are the same */
 	}
 
-
 	return;
-
 }
 
 int RBTestInvariants(RB *tree)
@@ -1199,71 +1239,71 @@ int RBTestInvariants(RB *tree)
 	int all_black_same;
 	int black_count;
 
-	if((tree->prev == NULL) && (tree->next == NULL) && (tree->left == NULL))
+	if ((tree->prev == NULL) && (tree->next == NULL) && (tree->left == NULL))
 	{
-		return(1);
+		return (1);
 	}
 
 	/*
 	 * tree left is the top of the tree
 	 */
-	if(tree->left->color != RB_BLACK)
+	if (tree->left->color != RB_BLACK)
 	{
-		fprintf(stderr,"root isn't black\n");
-		return(0);
+		fprintf(stderr, "root isn't black\n");
+		return (0);
 	}
 
 	both_black = 1;
-	RBTestChildColor(tree->left,&both_black);
+	RBTestChildColor(tree->left, &both_black);
 
-	if(both_black == 0)
+	if (both_black == 0)
 	{
-		fprintf(stderr,"both black children of red fails\n");
-		return(0);
+		fprintf(stderr, "both black children of red fails\n");
+		return (0);
 	}
 
 	all_black_same = 1;
-	RBTestPaths(tree->left,&black_count,&all_black_same);
+	RBTestPaths(tree->left, &black_count, &all_black_same);
 
-	if(all_black_same == 0)
+	if (all_black_same == 0)
 	{
-		fprintf(stderr,"black path invariant fails\n");
-		return(0);
+		fprintf(stderr, "black path invariant fails\n");
+		return (0);
 	}
 
-	return(1);
+	return (1);
 }
 
 void RBPrintNode(RB *node)
 {
-	switch(node->key.type)
+	switch (node->key.type)
 	{
-		case K_INT:
-	printf("n: 0x%x, key: %d color: %d, l: 0x%x, r: 0x%x p: 0x%x\n",
-		node,
-		node->key.key.i,
-		node->color,
-		node->left,
-		node->right,
-		node->parent);
+	case K_INT:
+		printf("n: 0x%x, key: %d color: %d, l: 0x%x, r: 0x%x p: 0x%x\n",
+			   node,
+			   node->key.key.i,
+			   node->color,
+			   node->left,
+			   node->right,
+			   node->parent);
 		break;
-		case K_DOUBLE:
-	printf("n: 0x%x, key: %f color: %d, l: 0x%x, r: 0x%x p: 0x%x\n",
-		node,
-		node->key.key.d,
-		node->color,
-		node->left,
-		node->right,
-		node->parent);
+	case K_DOUBLE:
+		printf("n: 0x%x, key: %f color: %d, l: 0x%x, r: 0x%x p: 0x%x\n",
+			   node,
+			   node->key.key.d,
+			   node->color,
+			   node->left,
+			   node->right,
+			   node->parent);
 		break;
-		case K_STRING:
-	printf("n: 0x%x, key: %s color: %d, l: 0x%x, r: 0x%x p: 0x%x\n",
-		node,
-		node->key.key.s,
-		node->color,
-		node->left,
-		node->right,
-		node->parent);
+	case K_STRING:
+		printf("n: 0x%x, key: %s color: %d, l: 0x%x, r: 0x%x p: 0x%x\n",
+			   node,
+			   node->key.key.s,
+			   node->color,
+			   node->left,
+			   node->right,
+			   node->parent);
 		break;
 	}
 
@@ -1277,28 +1317,28 @@ void RBPrintTree(RB *tree)
 	RB *node;
 
 	que = DlistInit();
-	if(que == NULL)
+	if (que == NULL)
 	{
 		return;
 	}
 
 	value.v = (void *)tree->left;
-	DlistAppend(que,value);
+	DlistAppend(que, value);
 
-	while(que->count != 0)
+	while (que->count != 0)
 	{
 		node = (RB *)(que->first->value.v);
 		RBPrintNode(node);
-		DlistDelete(que,que->first);
-		if(node->left)
+		DlistDelete(que, que->first);
+		if (node->left)
 		{
 			value.v = (void *)node->left;
-			DlistAppend(que,value);
+			DlistAppend(que, value);
 		}
-		if(node->right)
+		if (node->right)
 		{
 			value.v = (void *)node->right;
-			DlistAppend(que,value);
+			DlistAppend(que, value);
 		}
 	}
 
@@ -1312,7 +1352,7 @@ void RBPrintTree(RB *tree)
 
 int rbyan()
 {
-	return(0);
+	return (0);
 }
 
 #define MAX_DEL_COUNT (40)
@@ -1333,35 +1373,35 @@ int main(int argc, char *argv[])
 	int count;
 
 	tree = RBInitD();
-	if(tree == NULL)
+	if (tree == NULL)
 	{
-		fprintf(stderr,"failed to make tree\n");
+		fprintf(stderr, "failed to make tree\n");
 		exit(1);
 	}
 
 	del_count = 0;
-	del_key = (double *)malloc(MAX_DEL_COUNT*sizeof(double));
+	del_key = (double *)malloc(MAX_DEL_COUNT * sizeof(double));
 
-	for(i=0; i < 200; i++)
+	for (i = 0; i < 200; i++)
 	{
 		r = drand48();
-		printf("inserting: %f\n",r);
-		RBInsertD(tree,r,(Hval)0);
+		printf("inserting: %f\n", r);
+		RBInsertD(tree, r, (Hval)0);
 		RBPrintTree(tree);
 		status = RBTestGPs(tree);
-		if(status == 0)
+		if (status == 0)
 		{
 			printf("RB tree fails GP test\n");
 			break;
 		}
 		status = RBTestInvariants(tree);
-		if(status == 0)
+		if (status == 0)
 		{
 			printf("RB tree fails invarant test\n");
 			break;
 		}
 
-		if((drand48() < 0.1) && (del_count < MAX_DEL_COUNT))
+		if ((drand48() < 0.1) && (del_count < MAX_DEL_COUNT))
 		{
 			del_key[del_count] = r;
 			del_count++;
@@ -1369,17 +1409,17 @@ int main(int argc, char *argv[])
 	}
 
 	curr = tree->prev;
-	while(curr != NULL)
+	while (curr != NULL)
 	{
-		printf("sorted: %f\n",K_D(curr->key));
+		printf("sorted: %f\n", K_D(curr->key));
 		curr = curr->next;
 	}
 
-	for(i=0; i < del_count; i++)
+	for (i = 0; i < del_count; i++)
 	{
-		printf("searching for %f\n",del_key[i]);
-		node = RBFindD(tree,del_key[i]);
-		if(node != NULL)
+		printf("searching for %f\n", del_key[i]);
+		node = RBFindD(tree, del_key[i]);
+		if (node != NULL)
 		{
 			printf("\tfound\n");
 		}
@@ -1389,11 +1429,11 @@ int main(int argc, char *argv[])
 			exit(1);
 		}
 
-		printf("deleteing %f\n",del_key[i]);
-		RBDeleteD(tree,node);
-//		RBPrintTree(tree);
+		printf("deleteing %f\n", del_key[i]);
+		RBDeleteD(tree, node);
+		//		RBPrintTree(tree);
 		status = RBTestInvariants(tree);
-		if(status == 0)
+		if (status == 0)
 		{
 			printf("RB tree fails invarant test\n");
 			exit(1);
@@ -1403,19 +1443,19 @@ int main(int argc, char *argv[])
 	/*
 	 * let's try deleting the root
 	 */
-	printf("deleting root: %f\n",K_D(tree->left->key));
-	RBDeleteD(tree,tree->left);
+	printf("deleting root: %f\n", K_D(tree->left->key));
+	RBDeleteD(tree, tree->left);
 	status = RBTestInvariants(tree);
-	if(status == 0)
+	if (status == 0)
 	{
 		printf("RB tree fails invarant test after root\n");
 		exit(1);
 	}
-	printf("new root: %f\n",K_D(tree->left->key));
+	printf("new root: %f\n", K_D(tree->left->key));
 	curr = tree->prev;
-	while(curr != NULL)
+	while (curr != NULL)
 	{
-		printf("sorted: %f\n",K_D(curr->key));
+		printf("sorted: %f\n", K_D(curr->key));
 		curr = curr->next;
 	}
 
@@ -1423,109 +1463,105 @@ int main(int argc, char *argv[])
 	RBDestroyD(tree);
 
 	tree = RBInitD();
-	if(tree == NULL)
+	if (tree == NULL)
 	{
-		fprintf(stderr,"couldn't get new tree\n");
+		fprintf(stderr, "couldn't get new tree\n");
 		exit(1);
 	}
 
 	printf("doing big insert\n");
-	for(i=0; i < BIG_COUNT; i++)
+	for (i = 0; i < BIG_COUNT; i++)
 	{
 		r = drand48();
-		RBInsertD(tree,r,(Hval)0);
+		RBInsertD(tree, r, (Hval)0);
 		status = RBTestInvariants(tree);
-		if(status == 0)
+		if (status == 0)
 		{
 			printf("RB tree fails big invarant test\n");
 			break;
 		}
 	}
 
-
 	count = BIG_COUNT;
 	printf("doing big delete test\n");
 
-	while(count > 10)
+	while (count > 10)
 	{
 		r = drand48();
 		curr = tree->prev;
-		for(i=0; i < (int)(r*count); i++)
+		for (i = 0; i < (int)(r * count); i++)
 		{
-			if(CompareKeyType(tree->prev->key,tree->prev->next->key) > 0)
+			if (CompareKeyType(tree->prev->key, tree->prev->next->key) > 0)
 			{
 				printf("bad sequence\n");
 				exit(1);
 			}
 			curr = curr->next;
 		}
-		printf("deleting: %20.30e\n",K_D(curr->key));
-		RBDeleteD(tree,curr);
+		printf("deleting: %20.30e\n", K_D(curr->key));
+		RBDeleteD(tree, curr);
 		status = RBTestInvariants(tree);
-		if(status == 0)
+		if (status == 0)
 		{
-			printf("RB tree fails big delete %d\n",count);
+			printf("RB tree fails big delete %d\n", count);
 			exit(1);
 		}
 		count--;
 	}
-		
 
 	curr = tree->prev;
-	while(curr != NULL)
+	while (curr != NULL)
 	{
-		printf("sorted: %f\n",K_D(curr->key));
+		printf("sorted: %f\n", K_D(curr->key));
 		curr = curr->next;
 	}
 
 	printf("deleteing first\n");
-	RBDeleteD(tree,RB_FIRST(tree));
+	RBDeleteD(tree, RB_FIRST(tree));
 	status = RBTestInvariants(tree);
-	if(status == 0)
+	if (status == 0)
 	{
-		fprintf(stderr,"first delete fails\n");
+		fprintf(stderr, "first delete fails\n");
 		exit(1);
 	}
 	curr = RB_FIRST(tree);
-	while(curr != NULL)
+	while (curr != NULL)
 	{
-		printf("sorted: %f\n",K_D(curr->key));
+		printf("sorted: %f\n", K_D(curr->key));
 		curr = curr->next;
 	}
 
 	printf("deleteing last\n");
-	RBDeleteD(tree,RB_LAST(tree));
+	RBDeleteD(tree, RB_LAST(tree));
 	status = RBTestInvariants(tree);
-	if(status == 0)
+	if (status == 0)
 	{
-		fprintf(stderr,"last delete fails\n");
+		fprintf(stderr, "last delete fails\n");
 		exit(1);
 	}
 	curr = RB_LAST(tree);
-	while(curr != NULL)
+	while (curr != NULL)
 	{
-		printf("sorted: %f\n",K_D(curr->key));
+		printf("sorted: %f\n", K_D(curr->key));
 		curr = curr->prev;
 	}
 
 	curr = RB_FIRST(tree);
-	while(curr != NULL)
+	while (curr != NULL)
 	{
 		next = curr->next;
-		printf("deleteing %f\n",K_D(curr->key));
-		RBDeleteD(tree,curr);
+		printf("deleteing %f\n", K_D(curr->key));
+		RBDeleteD(tree, curr);
 		status = RBTestInvariants(tree);
-		if(status == 0)
+		if (status == 0)
 		{
-			fprintf(stderr,"intermediate delete failed\n");
+			fprintf(stderr, "intermediate delete failed\n");
 			exit(1);
 		}
 		curr = next;
 	}
-	
-        return(0);
+
+	return (0);
 }
 
-
 #endif
-

--- a/apps/runs-test/ks/red_black/red_black_2.h
+++ b/apps/runs-test/ks/red_black/red_black_2.h
@@ -14,6 +14,7 @@ typedef struct key_type_stc KEY_t;
 #define K_INT (1)
 #define K_DOUBLE (2)
 #define K_STRING (3)
+#define K_INT64 (4)
 
 struct rb_stc
 {

--- a/event.c
+++ b/event.c
@@ -41,11 +41,11 @@ int EventSetCause(EVENT *ev, unsigned long cause_host,
 	return (1);
 }
 
-double EventIndex(unsigned long host, unsigned long long seq_no)
+int64_t EventIndex(unsigned long host, unsigned long long seq_no)
 {
-	double ndx;
+	int64_t ndx;
 
-	ndx = (double)(((double)host * pow(2, 32)) + (double)seq_no);
+	ndx = ((int64_t)host << 32) + (int64_t)seq_no;
 
 	return (ndx);
 }

--- a/event.h
+++ b/event.h
@@ -36,6 +36,6 @@ void EventFree(EVENT *ev);
 int EventSetCause(EVENT *ev, unsigned long cause_host,
 				  unsigned long long cause_seq_no);
 
-double EventIndex(unsigned long host, unsigned long long seq_no);
+int64_t EventIndex(unsigned long host, unsigned long long seq_no);
 
 #endif

--- a/log.c
+++ b/log.c
@@ -327,17 +327,17 @@ PENDING *PendingCreate(char *filename, unsigned long psize)
 	pending = (PENDING *)MIOAddr(mio);
 	memset(pending, 0, sizeof(PENDING));
 
-	pending->alive = RBInitD();
+	pending->alive = RBInitI64();
 	if (pending->alive == NULL)
 	{
 		MIOClose(mio);
 		return (NULL);
 	}
 
-	pending->causes = RBInitD();
+	pending->causes = RBInitI64();
 	if (pending->causes == NULL)
 	{
-		RBDestroyD(pending->alive);
+		RBDestroyI64(pending->alive);
 		MIOClose(mio);
 		return (NULL);
 	}
@@ -362,12 +362,12 @@ void PendingFree(PENDING *pending)
 
 	if (pending->alive != NULL)
 	{
-		RBDestroyD(pending->alive);
+		RBDestroyI64(pending->alive);
 	}
 
 	if (pending->causes != NULL)
 	{
-		RBDestroyD(pending->causes);
+		RBDestroyI64(pending->causes);
 	}
 
 	if (pending->p_mio != NULL)
@@ -380,7 +380,7 @@ void PendingFree(PENDING *pending)
 
 int PendingAddEvent(PENDING *pending, EVENT *event)
 {
-	double ndx;
+	int64_t ndx;
 	EVENT *local_event;
 	unsigned long start;
 	EVENT *ev_array;
@@ -422,10 +422,10 @@ int PendingAddEvent(PENDING *pending, EVENT *event)
 	}
 	memcpy(&ev_array[pending->next_free], event, sizeof(EVENT));
 	ndx = EventIndex(event->host, event->seq_no);
-	RBInsertD(pending->alive, ndx,
+	RBInsertI64(pending->alive, ndx,
 			  (Hval)(void *)(&ev_array[pending->next_free]));
 	ndx = EventIndex(event->cause_host, event->cause_seq_no);
-	RBInsertD(pending->causes, ndx,
+	RBInsertI64(pending->causes, ndx,
 			  (Hval)(void *)(&ev_array[pending->next_free]));
 
 	return (1);
@@ -437,11 +437,11 @@ int PendingRemoveEvent(PENDING *pending, EVENT *event)
 	RB *start;
 	EVENT *local_event;
 	EVENT *this_event;
-	double ndx;
+	int64_t ndx;
 	int found = 0;
 
 	ndx = EventIndex(event->host, event->seq_no);
-	rb = RBFindD(pending->alive, ndx);
+	rb = RBFindI64(pending->alive, ndx);
 	if (rb == NULL)
 	{
 		fprintf(stderr,
@@ -452,7 +452,7 @@ int PendingRemoveEvent(PENDING *pending, EVENT *event)
 		return (-1);
 	}
 	local_event = (EVENT *)rb->value.v;
-	RBDeleteD(pending->alive, rb);
+	RBDeleteI64(pending->alive, rb);
 
 	/*
 	 * there could be multiple events with the same cause event
@@ -461,7 +461,7 @@ int PendingRemoveEvent(PENDING *pending, EVENT *event)
 	 */
 	ndx = EventIndex(event->cause_host, event->cause_seq_no);
 
-	start = RBFindD(pending->causes, ndx);
+	start = RBFindI64(pending->causes, ndx);
 	if (start == NULL)
 	{
 		fprintf(stderr,
@@ -476,7 +476,7 @@ int PendingRemoveEvent(PENDING *pending, EVENT *event)
 	{
 		if (rb->value.v == local_event)
 		{
-			RBDeleteD(pending->causes, rb);
+			RBDeleteI64(pending->causes, rb);
 			local_event->seq_no = 0; /* marks MIO space as free */
 			return (1);
 		}
@@ -487,7 +487,7 @@ int PendingRemoveEvent(PENDING *pending, EVENT *event)
 	{
 		if (rb->value.v == local_event)
 		{
-			RBDeleteD(pending->causes, rb);
+			RBDeleteI64(pending->causes, rb);
 			local_event->seq_no = 0; /* marks MIO space as free */
 			return (1);
 		}
@@ -499,11 +499,11 @@ int PendingRemoveEvent(PENDING *pending, EVENT *event)
 
 EVENT *PendingFindEvent(PENDING *pending, unsigned long host, unsigned long long seq_no)
 {
-	double ndx = EventIndex(host, seq_no);
+	int64_t ndx = EventIndex(host, seq_no);
 	RB *rb;
 	EVENT *ev;
 
-	rb = RBFindD(pending->alive, ndx);
+	rb = RBFindI64(pending->alive, ndx);
 	if (rb == NULL)
 	{
 		return (NULL);
@@ -525,11 +525,11 @@ EVENT *PendingFindEvent(PENDING *pending, unsigned long host, unsigned long long
 
 EVENT *PendingFindCause(PENDING *pending, unsigned long host, unsigned long long seq_no)
 {
-	double ndx = EventIndex(host, seq_no);
+	int64_t ndx = EventIndex(host, seq_no);
 	RB *rb;
 	EVENT *ev;
 
-	rb = RBFindD(pending->causes, ndx);
+	rb = RBFindI64(pending->causes, ndx);
 	if (rb == NULL)
 	{
 		return (NULL);
@@ -856,7 +856,7 @@ int IsAnchor(EVENT *ev)
 
 int GLogEvent(GLOG *gl, EVENT *event)
 {
-	double ndx;
+	int64_t ndx;
 	unsigned long host_id;
 	unsigned long long seq_no;
 	unsigned long long cause_seq_no;


### PR DESCRIPTION
Type double causes key collision. Added int64_t to RBTree to avoid that.