### PR TITLE
1. WooFRead when nothing in woof 2. RegressPairPredictedHandler.c

### DIFF
--- a/apps/regress-pair/RegressPairPredictedHandler.c
+++ b/apps/regress-pair/RegressPairPredictedHandler.c
@@ -342,6 +342,10 @@ ntohl(p_rv.tv_sec),p_rv.value.d,ntohl(m_rv.tv_sec),m_rv.value.d,count,measured_s
 	}
 
 	earliest_seq_no = seq_no;
+	if (earliest_seq_no == 0)
+	{
+		earliest_seq_no = 1;
+	}
 
 	/*
 	 * start with unsmoothed series

--- a/apps/regress-pair/RegressPairPredictedHandler.c
+++ b/apps/regress-pair/RegressPairPredictedHandler.c
@@ -809,21 +809,23 @@ fflush(stdout);
 			m_seq_no--;
 			err = WooFGet(measured_name,(void *)&mv,m_seq_no);
 		}
-		if(err < 0) {
-			fprintf(stderr,"couldn't find valid measurement for request %lu\n",
-				rv->seq_no);
-			RBDestroyD(sorted_meas);
-			FinishPredicted(finished_name,wf_seq_no);
-			return(-1);
+		if (mcount == 0)
+		{
+			if(err < 0) {
+				fprintf(stderr,"couldn't find valid measurement for request %lu\n",
+					rv->seq_no);
+				RBDestroyD(sorted_meas);
+				FinishPredicted(finished_name,wf_seq_no);
+				return(-1);
+			}
+			if(m_seq_no == 0) {
+				fprintf(stderr,"couldn't find meas ts earlier that %10.0f, using %10.0f\n",
+						p_ts,m_ts);
+				RBDestroyD(sorted_meas);
+				FinishPredicted(finished_name,wf_seq_no);
+				return(-1);
+			}
 		}
-		if(m_seq_no == 0) {
-			fprintf(stderr,"couldn't find meas ts earlier that %10.0f, using %10.0f\n",
-					p_ts,m_ts);
-			RBDestroyD(sorted_meas);
-			FinishPredicted(finished_name,wf_seq_no);
-		}
-
-		
 	}
 	
 	if((c_seq_no > 0) && (mcount > 0)) {

--- a/woofc.c
+++ b/woofc.c
@@ -309,10 +309,10 @@ WOOF *WooFOpen(char *name)
 	}
 #ifdef DEBUG
 	printf("WooFOpen: trying to open %s from fname %s, %s with dir %s\n",
-		local_name,
-		fname,
-		name,
-		WooF_dir);
+		   local_name,
+		   fname,
+		   name,
+		   WooF_dir);
 	fflush(stdout);
 #endif
 
@@ -1191,6 +1191,15 @@ int WooFRead(WOOF *wf, void *element, unsigned long seq_no)
 	el_id = (ELID *)(ptr + wfs->element_size);
 	youngest = el_id->seq_no;
 
+	if (youngest == 0)
+	{
+		V(&wfs->mutex);
+		fprintf(stderr, "WooFRead: youngest seq_no is 0, there is nothing in woof %s\n",
+				wfs->filename);
+		fflush(stderr);
+		return (-1);
+	}
+
 	last_valid = wfs->tail;
 	ptr = buf + (last_valid * (wfs->element_size + sizeof(ELID)));
 	el_id = (ELID *)(ptr + wfs->element_size);
@@ -1221,9 +1230,9 @@ int WooFRead(WOOF *wf, void *element, unsigned long seq_no)
 	if ((seq_no < oldest) || (seq_no > youngest))
 	{
 		V(&wfs->mutex);
-		fprintf(stdout, "WooFRead: seq_no not in range: seq_no: %lu, oldest: %lu, youngest: %lu\n",
+		fprintf(stderr, "WooFRead: seq_no not in range: seq_no: %lu, oldest: %lu, youngest: %lu\n",
 				seq_no, oldest, youngest);
-		fflush(stdout);
+		fflush(stderr);
 		return (-1);
 	}
 

--- a/woofc.c
+++ b/woofc.c
@@ -309,10 +309,10 @@ WOOF *WooFOpen(char *name)
 	}
 #ifdef DEBUG
 	printf("WooFOpen: trying to open %s from fname %s, %s with dir %s\n",
-		   local_name,
-		   fname,
-		   name,
-		   WooF_dir);
+		local_name,
+		fname,
+		name,
+		WooF_dir);
 	fflush(stdout);
 #endif
 
@@ -883,6 +883,7 @@ int WooFHandlerDone(char *wf_name, unsigned long seq_no)
 	fflush(stdout);
 #endif
 
+
 	memset(ns_ip, 0, sizeof(ns_ip));
 	err = WooFIPAddrFromURI(wf_name, ns_ip, sizeof(ns_ip));
 	if (err < 0)
@@ -1181,6 +1182,10 @@ int WooFRead(WOOF *wf, void *element, unsigned long seq_no)
 	unsigned long ndx;
 	ELID *el_id;
 
+	if((seq_no == 0) || WooFInvalid(seq_no)) {
+		return(-1);
+	}
+
 	wfs = wf->shared;
 
 	buf = (unsigned char *)(((void *)wfs) + sizeof(WOOF_SHARED));
@@ -1190,15 +1195,6 @@ int WooFRead(WOOF *wf, void *element, unsigned long seq_no)
 	ptr = buf + (wfs->head * (wfs->element_size + sizeof(ELID)));
 	el_id = (ELID *)(ptr + wfs->element_size);
 	youngest = el_id->seq_no;
-
-	if (youngest == 0)
-	{
-		V(&wfs->mutex);
-		fprintf(stderr, "WooFRead: youngest seq_no is 0, there is nothing in woof %s\n",
-				wfs->filename);
-		fflush(stderr);
-		return (-1);
-	}
 
 	last_valid = wfs->tail;
 	ptr = buf + (last_valid * (wfs->element_size + sizeof(ELID)));
@@ -1230,9 +1226,9 @@ int WooFRead(WOOF *wf, void *element, unsigned long seq_no)
 	if ((seq_no < oldest) || (seq_no > youngest))
 	{
 		V(&wfs->mutex);
-		fprintf(stderr, "WooFRead: seq_no not in range: seq_no: %lu, oldest: %lu, youngest: %lu\n",
+		fprintf(stdout, "WooFRead: seq_no not in range: seq_no: %lu, oldest: %lu, youngest: %lu\n",
 				seq_no, oldest, youngest);
-		fflush(stderr);
+		fflush(stdout);
 		return (-1);
 	}
 


### PR DESCRIPTION
1.
WooFRead should return error when there's nothing in the woof.
If there's nothing in the woof, `youngest` and `oldest` are both 0. `WooFRead(0)` would `return (1)` instead of `(-1)` before this patch.

2.
In RegressPairPredictedHandler(), there are cases where some measured woof are found between p_ts and e_ts(m_count > 0), but (err < 0) or (m_seq_no == 0). Add an if block to avoid these cases.