### PR TITLE
remove WooFFree(), replaced with WooFDrop()

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .DS_Store
+.vscode

--- a/woofc-access.c
+++ b/woofc-access.c
@@ -720,7 +720,7 @@ void WooFProcessGetElSize(zmsg_t *req_msg, zsock_t *receiver)
 	else
 	{
 		el_size = wf->shared->element_size;
-		WooFFree(wf);
+		WooFDrop(wf);
 	}
 
 #ifdef DEBUG
@@ -835,7 +835,7 @@ void WooFProcessGetLatestSeqno(zmsg_t *req_msg, zsock_t *receiver)
 	else
 	{
 		latest_seq_no = WooFLatestSeqno(wf);
-		WooFFree(wf);
+		WooFDrop(wf);
 	}
 
 #ifdef DEBUG
@@ -1144,7 +1144,7 @@ void WooFProcessGetTail(zmsg_t *req_msg, zsock_t *receiver)
 	else
 	{
 		el_size = wf->shared->element_size;
-//		WooFFree(wf);
+//		WooFDrop(wf);
 	}
 
 	if (wf != NULL)
@@ -1154,12 +1154,12 @@ void WooFProcessGetTail(zmsg_t *req_msg, zsock_t *receiver)
 		{
 			fprintf(stderr, "WooFProcessGetTail: couldn't open %s\n", woof_name);
 			fflush(stderr);
-			WooFFree(wf);
+			WooFDrop(wf);
 			return;
 		}
 
 		el_read = WooFReadTail(wf, ptr, el_count);
-		WooFFree(wf);
+		WooFDrop(wf);
 		wf = NULL;
 	}
 
@@ -1362,7 +1362,7 @@ void WooFProcessGet(zmsg_t *req_msg, zsock_t *receiver)
 					el_size = 0;
 				}
 			}
-			WooFFree(wf);
+			WooFDrop(wf);
 		}
 	}
 	else
@@ -1535,7 +1535,7 @@ void WooFProcessGetDone(zmsg_t *req_msg, zsock_t *receiver)
 		else
 		{
 			done = wf->shared->done;
-			WooFFree(wf);
+			WooFDrop(wf);
 		}
 	}
 	else

--- a/woofc-container.c
+++ b/woofc-container.c
@@ -750,7 +750,7 @@ void *WooFForker(void *arg)
 			earg[0] = pbuf;
 			earg[1] = NULL;
 
-			WooFFree(wf);
+			WooFDrop(wf);
 
 			execve(pbuf, earg, eenvp);
 

--- a/woofc-shepherd.c
+++ b/woofc-shepherd.c
@@ -416,7 +416,7 @@ int main(int argc, char **argv, char **envp)
 	}
 
 #ifdef DEBUG
-	fprintf(stdout, "WooFShepherd: calling WooFFree, seq_no: %lu\n", seq_no);
+	fprintf(stdout, "WooFShepherd: calling WooFDrop, seq_no: %lu\n", seq_no);
 	fflush(stdout);
 #endif
 	WooFDrop(wf);

--- a/woofc.c
+++ b/woofc.c
@@ -331,11 +331,6 @@ WOOF *WooFOpen(char *name)
 	return (wf);
 }
 
-void WooFFree(WOOF *wf)
-{
-	return;
-}
-
 void WooFDrop(WOOF *wf)
 {
 	MIOClose(wf->mio);
@@ -365,7 +360,7 @@ int WooFTruncate(char *name, unsigned long seq_no) {
 			fflush(stderr);
 			V(&wfs->mutex);
 			V(&wfs->tail_wait);
-			WooFFree(wf);
+			WooFDrop(wf);
 			return -1;
 		}
 
@@ -377,7 +372,7 @@ int WooFTruncate(char *name, unsigned long seq_no) {
 	
 	V(&wfs->mutex);
 	V(&wfs->tail_wait);
-	WooFFree(wf);
+	WooFDrop(wf);
 
 	return 1;
 }
@@ -722,7 +717,7 @@ unsigned long WooFPut(char *wf_name, char *hand_name, void *element)
 #endif
 	seq_no = WooFAppend(wf, hand_name, element);
 
-	WooFFree(wf);
+	WooFDrop(wf);
 	return (seq_no);
 }
 
@@ -814,7 +809,7 @@ int WooFGet(char *wf_name, void *element, unsigned long seq_no)
 #endif
 	err = WooFRead(wf, element, seq_no);
 
-	WooFFree(wf);
+	WooFDrop(wf);
 	return (err);
 }
 
@@ -905,7 +900,7 @@ int WooFHandlerDone(char *wf_name, unsigned long seq_no)
 		retval = 0;
 	}
 
-	WooFFree(wf);
+	WooFDrop(wf);
 	return (retval);
 }
 
@@ -988,7 +983,7 @@ unsigned long WooFGetLatestSeqno(char *wf_name)
 #endif
 	latest_seq_no = WooFLatestSeqno(wf);
 
-	WooFFree(wf);
+	WooFDrop(wf);
 	return (latest_seq_no);
 }
 
@@ -1118,7 +1113,7 @@ unsigned long WooFGetTail(char *wf_name, void *elements, unsigned long element_c
 #endif
 	err = WooFReadTail(wf, elements, element_count);
 
-	WooFFree(wf);
+	WooFDrop(wf);
 	return (err);
 }
 


### PR DESCRIPTION
WooFFree() doesn't do anything, yet many functions are calling WooFFree() to free the opened WOOF.

This commit removes WooFFree() and replaces all WooFFree() calls with WooFDrop().